### PR TITLE
Convert claim attributes to new list of objects

### DIFF
--- a/dominos.go
+++ b/dominos.go
@@ -134,9 +134,18 @@ func linkDominos(c *gin.Context) {
 		wiis.([]middleware.Wii)[i].DominosLinked = !wii.DominosLinked
 	}
 
+	publicProfile, ok := c.Get("public_profile")
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"error":   "failed to get public_profile",
+		})
+	}
+
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"wiis": wiis,
+			"public_profile": publicProfile,
+			"wiis":           wiis,
 		},
 	}
 

--- a/dominos.go
+++ b/dominos.go
@@ -4,14 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/WiiLink24/nwc24"
-	"github.com/gin-gonic/gin"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/WiiLink24/AccountManager/middleware"
+	"github.com/WiiLink24/nwc24"
+	"github.com/gin-gonic/gin"
 )
 
 type refreshResult struct {
@@ -121,24 +123,20 @@ func linkDominos(c *gin.Context) {
 
 	// Finally we toggle linked in authentik API.
 	wiis, _ := c.Get("wiis")
-	wwfc, _ := c.Get("wwfc")
-	dominos, _ := c.Get("dominos")
-	justEat, _ := c.Get("just_eat")
 	uid, _ := c.Get("uid")
 
-	// Toggle the linkage
-	if dominos.(map[string]bool)[wiiNoStr] {
-		dominos.(map[string]bool)[wiiNoStr] = false
-	} else {
-		dominos.(map[string]bool)[wiiNoStr] = true
+	for i, wii := range wiis.([]middleware.Wii) {
+		if wii.WiiNumber != wiiNoStr {
+			continue
+		}
+
+		// Toggle
+		wiis.([]middleware.Wii)[i].DominosLinked = !wii.DominosLinked
 	}
 
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"wiis":     wiis,
-			"wwfc":     wwfc,
-			"dominos":  dominos,
-			"just_eat": justEat,
+			"wiis": wiis,
 		},
 	}
 

--- a/just_eat.go
+++ b/just_eat.go
@@ -95,12 +95,13 @@ func justEatSocketListen() {
 				}
 
 				// Toggle
-				claims.Wiis[i].JustEatLinked = !wii.JustEatLinked
+				claims.Wiis[i].JustEatLinked = true
 			}
 
 			newPayload := map[string]any{
 				"attributes": map[string]any{
-					"wiis": claims.Wiis,
+					"public_profile": claims.PublicProfile,
+					"wiis":           claims.Wiis,
 				},
 			}
 

--- a/just_eat.go
+++ b/just_eat.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"github.com/WiiLink24/AccountManager/middleware"
-	"github.com/logrusorgru/aurora/v4"
 	"log"
 	"net"
 	"net/http"
@@ -12,6 +10,9 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/WiiLink24/AccountManager/middleware"
+	"github.com/logrusorgru/aurora/v4"
 )
 
 const SocketSuccess = `{"success": true}`
@@ -88,20 +89,18 @@ func justEatSocketListen() {
 				return
 			}
 
-			// Toggle the linkage
-			if claims.JustEat[justEatPayload.WiiNumber] {
-				claims.JustEat[justEatPayload.WiiNumber] = false
-			} else {
-				claims.JustEat[justEatPayload.WiiNumber] = true
+			for i, wii := range claims.Wiis {
+				if wii.WiiNumber != justEatPayload.WiiNumber {
+					continue
+				}
+
+				// Toggle
+				claims.Wiis[i].JustEatLinked = !wii.JustEatLinked
 			}
 
-			// Now send off to authentik.
 			newPayload := map[string]any{
 				"attributes": map[string]any{
-					"wiis":     claims.Wiis,
-					"wwfc":     claims.WWFC,
-					"dominos":  claims.Dominos,
-					"just_eat": claims.JustEat,
+					"wiis": claims.Wiis,
 				},
 			}
 

--- a/link.go
+++ b/link.go
@@ -50,6 +50,7 @@ func linkRedirect(c *gin.Context) {
 func link(c *gin.Context) {
 	wiiNumber := c.PostForm("wii_num")
 	wwfcCert := c.PostForm("cert")
+	serialNumber := c.PostForm("serno")
 
 	// Verify cert first
 	ngId, err := verifySignature("WIILINK_ACCOUNT_LINKER", wwfcCert)
@@ -98,24 +99,25 @@ func link(c *gin.Context) {
 	}
 
 	wiis := _wiis.([]middleware.Wii)
-	if slices.ContainsFunc(wiis, func(w middleware.Wii) bool {
+	wiiIdx := slices.IndexFunc(wiis, func(w middleware.Wii) bool {
 		return w.WiiNumber == wiiNumber
-	}) {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"error":   "wii already linked",
-		})
-	}
+	})
 
-	// Now add the object
-	wii := middleware.Wii{
-		WiiNumber:     wiiNumber,
-		HollywoodID:   strconv.Itoa(int(ngId)),
-		DominosLinked: false,
-		JustEatLinked: false,
-	}
+	if wiiIdx != -1 {
+		// Wii is already linked, update object, presumably with serial number.
+		wiis[wiiIdx].SerialNumber = serialNumber
+	} else {
+		// Add new object
+		wii := middleware.Wii{
+			WiiNumber:     wiiNumber,
+			HollywoodID:   strconv.Itoa(int(ngId)),
+			DominosLinked: false,
+			JustEatLinked: false,
+			SerialNumber:  serialNumber,
+		}
 
-	wiis = append(wiis, wii)
+		wiis = append(wiis, wii)
+	}
 
 	uid, ok := c.Get("uid")
 	if !ok {
@@ -125,9 +127,18 @@ func link(c *gin.Context) {
 		})
 	}
 
+	publicProfile, ok := c.Get("public_profile")
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"error":   "failed to get public_profile",
+		})
+	}
+
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"wiis": wiis,
+			"public_profile": publicProfile,
+			"wiis":           wiis,
 		},
 	}
 

--- a/link.go
+++ b/link.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/WiiLink24/nwc24"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"slices"
 	"strconv"
+
+	"github.com/WiiLink24/AccountManager/middleware"
+	"github.com/WiiLink24/nwc24"
+	"github.com/gin-gonic/gin"
 )
 
 func updateUserRequest(uid any, payload map[string]any) error {
@@ -66,6 +68,7 @@ func link(c *gin.Context) {
 			"success": false,
 			"error":   err.Error(),
 		})
+		return
 	}
 
 	wiiNoObj := nwc24.LoadWiiNumber(uint64(intWiiNumber))
@@ -74,6 +77,7 @@ func link(c *gin.Context) {
 			"success": false,
 			"error":   "invalid wii number",
 		})
+		return
 	}
 
 	if wiiNoObj.GetHollywoodID() != ngId {
@@ -81,67 +85,37 @@ func link(c *gin.Context) {
 			"success": false,
 			"error":   "device id associated with the Wii Number does not match the Wii.",
 		})
+		return
 	}
 
-	// Add Wii number to list
-	wiis, ok := c.Get("wiis")
+	_wiis, ok := c.Get("wiis")
 	if !ok {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"error":   "failed to get wii numbers",
+			"error":   "failed to get wiis",
 		})
+		return
 	}
 
-	if !slices.Contains(wiis.([]string), wiiNumber) {
-		wiis = append(wiis.([]string), wiiNumber)
-	}
-
-	// Same for wwfc
-	wwfc, ok := c.Get("wwfc")
-	if !ok {
-		c.JSON(http.StatusOK, gin.H{
+	wiis := _wiis.([]middleware.Wii)
+	if slices.ContainsFunc(wiis, func(w middleware.Wii) bool {
+		return w.WiiNumber == wiiNumber
+	}) {
+		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
-			"error":   "failed to get WWFC accounts",
+			"error":   "wii already linked",
 		})
 	}
 
-	if !slices.Contains(wwfc.([]string), strconv.Itoa(int(ngId))) {
-		wwfc = append(wwfc.([]string), strconv.Itoa(int(ngId)))
+	// Now add the object
+	wii := middleware.Wii{
+		WiiNumber:     wiiNumber,
+		HollywoodID:   strconv.Itoa(int(ngId)),
+		DominosLinked: false,
+		JustEatLinked: false,
 	}
 
-	// For Dominos
-	dominos, ok := c.Get("dominos")
-	if !ok {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"error":   "failed to get dominos data",
-		})
-	}
-
-	dMap := dominos.(map[string]bool)
-	if len(dMap) == 0 {
-		dMap = map[string]bool{wiiNumber: false}
-	} else if _, ok := dMap[wiiNumber]; !ok {
-		// Dictionary is not empty, and the current Wii Number is not present.
-		dMap[wiiNumber] = false
-	}
-
-	// Same thing for Just Eat
-	justEat, ok := c.Get("just_eat")
-	if !ok {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"error":   "failed to get Just Eat data",
-		})
-	}
-
-	eatMap := justEat.(map[string]bool)
-	if len(eatMap) == 0 {
-		eatMap = map[string]bool{wiiNumber: false}
-	} else if _, ok := eatMap[wiiNumber]; !ok {
-		// Dictionary is not empty, and the current Wii Number is not present.
-		eatMap[wiiNumber] = false
-	}
+	wiis = append(wiis, wii)
 
 	uid, ok := c.Get("uid")
 	if !ok {
@@ -153,10 +127,7 @@ func link(c *gin.Context) {
 
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"wiis":     wiis,
-			"wwfc":     wwfc,
-			"dominos":  dMap,
-			"just_eat": eatMap,
+			"wiis": wiis,
 		},
 	}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -25,6 +25,7 @@ type Wii struct {
 	HollywoodID   string `json:"hollywood_id"`
 	DominosLinked bool   `json:"dominos_linked"`
 	JustEatLinked bool   `json:"just_eat_linked"`
+	SerialNumber  string `json:"serial_number"`
 }
 
 func GetClaims(verifier *oidc.IDTokenVerifier, tokenString string) (*Claims, int) {
@@ -77,6 +78,7 @@ func AuthenticationMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFunc {
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
+		c.Set("public_profile", claims.PublicProfile)
 		c.Next()
 	}
 }
@@ -100,6 +102,7 @@ func AuthenticationPOSTMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFun
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
+		c.Set("public_profile", claims.PublicProfile)
 		c.Next()
 	}
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,21 +4,27 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"net/http"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 type Claims struct {
-	Email    string          `json:"email"`
-	Username string          `json:"preferred_username"`
-	Name     string          `json:"name"`
-	UserId   string          `json:"sub"`
-	Groups   []string        `json:"groups"`
-	Wiis     []string        `json:"wiis"`
-	WWFC     []string        `json:"wwfc"`
-	Dominos  map[string]bool `json:"dominos"`
-	JustEat  map[string]bool `json:"just_eat"`
+	Email         string   `json:"email"`
+	Username      string   `json:"preferred_username"`
+	Name          string   `json:"name"`
+	UserId        string   `json:"sub"`
+	Groups        []string `json:"groups"`
+	Wiis          []Wii    `json:"wiis"`
+	PublicProfile bool     `json:"public_profile"`
+}
+
+type Wii struct {
+	WiiNumber     string `json:"wii_number"`
+	HollywoodID   string `json:"hollywood_id"`
+	DominosLinked bool   `json:"dominos_linked"`
+	JustEatLinked bool   `json:"just_eat_linked"`
 }
 
 func GetClaims(verifier *oidc.IDTokenVerifier, tokenString string) (*Claims, int) {
@@ -71,9 +77,6 @@ func AuthenticationMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFunc {
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
-		c.Set("wwfc", claims.WWFC)
-		c.Set("dominos", claims.Dominos)
-		c.Set("just_eat", claims.JustEat)
 		c.Next()
 	}
 }
@@ -97,9 +100,6 @@ func AuthenticationPOSTMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFun
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
-		c.Set("wwfc", claims.WWFC)
-		c.Set("dominos", claims.Dominos)
-		c.Set("just_eat", claims.JustEat)
 		c.Next()
 	}
 }

--- a/pages.go
+++ b/pages.go
@@ -1,42 +1,41 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"log"
 	"net/http"
-)
 
-const (
-	IsUserLinked     = `SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)`
-	GetWiiNumberUser = `SELECT wii_number FROM users WHERE email = $1`
-	GetLinkedDominos = `SELECT dominos_linked FROM users WHERE email = $1`
+	"github.com/WiiLink24/AccountManager/middleware"
+	"github.com/gin-gonic/gin"
 )
 
 func HomePage(c *gin.Context) {
 	username, _ := c.Get("username")
 	email, _ := c.Get("email")
 	wiis, _ := c.Get("wiis")
-	dominos, _ := c.Get("dominos")
 
-	exists := len(wiis.([]string)) != 0
+	exists := len(wiis.([]middleware.Wii)) != 0
+	dominos := map[string]bool{}
+	for _, wii := range wiis.([]middleware.Wii) {
+		dominos[wii.WiiNumber] = wii.DominosLinked
+	}
 
 	if exists {
 		log.Printf("User with username %s is linked!!!", username)
 
 		if pfp, ok := c.Get("picture"); ok {
 			c.HTML(http.StatusOK, "linked.html", gin.H{
-				"username":   username,
-				"email":      email,
-				"pfp":        pfp,
-				"wiiNumbers": wiis.([]string),
-				"dominos":    dominos.(map[string]bool),
+				"username": username,
+				"email":    email,
+				"pfp":      pfp,
+				"dominos":  dominos,
+				"wiis":     wiis.([]middleware.Wii),
 			})
 		} else {
 			c.HTML(http.StatusOK, "linked.html", gin.H{
-				"username":   username,
-				"email":      email,
-				"wiiNumbers": wiis.([]string),
-				"dominos":    dominos.(map[string]bool),
+				"username": username,
+				"email":    email,
+				"dominos":  dominos,
+				"wiis":     wiis.([]middleware.Wii),
 			})
 		}
 	} else {

--- a/templates/linked.html
+++ b/templates/linked.html
@@ -34,7 +34,7 @@
       <form method="post" action="/dominos/link" class="flex flex-row items-center gap-3">
         <select name="dominos_wii_no" class="!m-0 px-6 py-3 rounded-lg" style="color: black;">
           {{range $val := .wiis}}
-          <option value="{{ $val }}">{{ $val.WiiNumber }}</option>
+          <option value="{{ $val.WiiNumber }}">{{ $val.WiiNumber }}</option>
           {{end}}
         </select>
         <button id="toggle_button"

--- a/templates/linked.html
+++ b/templates/linked.html
@@ -33,8 +33,8 @@
       </p>
       <form method="post" action="/dominos/link" class="flex flex-row items-center gap-3">
         <select name="dominos_wii_no" class="!m-0 px-6 py-3 rounded-lg" style="color: black;">
-          {{range $val := .wiiNumbers}}
-          <option value="{{ $val }}">{{ $val }}</option>
+          {{range $val := .wiis}}
+          <option value="{{ $val }}">{{ $val.WiiNumber }}</option>
           {{end}}
         </select>
         <button id="toggle_button"
@@ -117,8 +117,6 @@
   const username = "{{.username}}";
   const pfp = "https://gravatar.com/avatar/{{.pfp}}";
   const email = "{{.email}}";
-  let wiiNumbers = "{{.wiiNumbers}}";
-  wiiNumbers = wiiNumbers.trim().replace(/^\[|\]$/g, '').split(/\s+/);
 
 </script>
 


### PR DESCRIPTION
Discussed in the WiiLink dev server, however tl;dr here:

Currently the structure for user attributes is:
```json
{"wiis": ["6323484792621658"], "wwfc": ["133803490"], "dominos": {"6323484792621658": true}}
```

This is was a terrible design decision back when only a singular Wii could be linked and nothing else (WWFC, Dominos, Just Eat, etc).

With the advent of new services being linked, we need a better format that is much easier to work with. Rather than the above, each Wii gets its own object with respective fields.

```json
{
  "wiis": [
    {
      "wii_number": "6323484792621658",
      "hollywood_id": "133803490",
      "dominos": false,
    }
  ]
}
```

This PR allows the middleware to support this new structure. This is an ongoing effort across multiple repositories.