### PR TITLE
fix: Parsing claims for new users.

### DIFF
--- a/link.go
+++ b/link.go
@@ -127,17 +127,9 @@ func link(c *gin.Context) {
 		})
 	}
 
-	publicProfile, ok := c.Get("public_profile")
-	if !ok {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"error":   "failed to get public_profile",
-		})
-	}
-
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"public_profile": publicProfile,
+			"public_profile": false,
 			"wiis":           wiis,
 		},
 	}

--- a/link.go
+++ b/link.go
@@ -127,9 +127,17 @@ func link(c *gin.Context) {
 		})
 	}
 
+	publicProfile, ok := c.Get("public_profile")
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"error":   "failed to get public_profile",
+		})
+	}
+
 	payload := map[string]any{
 		"attributes": map[string]any{
-			"public_profile": false,
+			"public_profile": publicProfile,
 			"wiis":           wiis,
 		},
 	}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -17,7 +17,7 @@ type Claims struct {
 	UserId        string   `json:"sub"`
 	Groups        []string `json:"groups"`
 	Wiis          []Wii    `json:"wiis"`
-	PublicProfile bool     `json:"public_profile"`
+	PublicProfile *bool    `json:"public_profile"`
 }
 
 type Wii struct {
@@ -78,7 +78,16 @@ func AuthenticationMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFunc {
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
-		c.Set("public_profile", claims.PublicProfile)
+
+		// Before a Wii is linked, there will be no custom claims.
+		// While "wiis" will default to a nil slice, "PublicProfile" can't
+		// and will be a nil pointer that we have to set to a default value.
+		if claims.PublicProfile != nil {
+			c.Set("public_profile", claims.PublicProfile)
+		} else {
+			c.Set("public_profile", false)
+		}
+
 		c.Next()
 	}
 }
@@ -102,7 +111,13 @@ func AuthenticationPOSTMiddleware(verifier *oidc.IDTokenVerifier) gin.HandlerFun
 
 		c.Set("uid", claims.UserId)
 		c.Set("wiis", claims.Wiis)
-		c.Set("public_profile", claims.PublicProfile)
+
+		if claims.PublicProfile != nil {
+			c.Set("public_profile", claims.PublicProfile)
+		} else {
+			c.Set("public_profile", false)
+		}
+
 		c.Next()
 	}
 }


### PR DESCRIPTION
Upon checking the logs, `/link/wii` is returning HTTP 307, which points to claims failing to be parsed. This is most likely due to the `PublicProfile` field being a `bool`. New users have no custom claims, meaning JSON parser cannot find `public_profile` and does not default to a value, rather error. For other fields such as `wiis` which is a slice, it can be set to nil. The fix to this is to make `PublicProfile` a `*bool`, allowing JSON parser to set to `nil` if it cannot be found.