### PR TITLE
Ignore CSS and HTML in Github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assets/** linguist-vendored
+templates/** linguist-vendored


### PR DESCRIPTION
Will allow AccountManager to be seen as a Go project rather than a CSS project due to the disproportionate amount of CSS lines to others.